### PR TITLE
bugfix - markdown was missing in location description detail page

### DIFF
--- a/location/templates/location/location/location_detail.html
+++ b/location/templates/location/location/location_detail.html
@@ -87,7 +87,7 @@
 
     {% if location.description %}
         <div class="spacer"></div>
-        <div class="object description">{{ location.description|safe }}</div>  
+        <div class="object description">{{ location.description|markdown|safe }}</div>  
       {% endif %}
 
       <div class="spacer"></div>


### PR DESCRIPTION
It seems that markdown was not processed at all when displaying the description, so that has changed.
resolves #268 