### PR TITLE
show map for unauthenticated users if configured

### DIFF
--- a/location/context_processors.py
+++ b/location/context_processors.py
@@ -9,5 +9,6 @@ def setting_data(request):
     'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
     'default_order': settings.DEFAULT_ORDER if hasattr(settings, 'DEFAULT_ORDER') else 'distance',
     'allow_unauthenticated_read_comments': settings.ALLOW_UNAUTHENTICATED_READ_COMMENTS if hasattr(settings, 'ALLOW_UNAUTHENTICATED_READ_COMMENTS') else False,
+    'allow_unauthenticated_see_overview_map': settings.ALLOW_UNAUTHENTICATED_SEE_OVERVIEW_MAP if hasattr(settings, 'ALLOW_UNAUTHENTICATED_SEE_OVERVIEW_MAP') else False,
     'departure_center': settings.DEPARTURE_CENTER if hasattr(settings, 'DEPARTURE_CENTER') else 'Domplein, Utrecht',
   }

--- a/location/templates/location/location/location_list_map.html
+++ b/location/templates/location/location/location_list_map.html
@@ -5,7 +5,7 @@
   {% comment %} {% include 'snippets/location_list_filters.html' %} {% endcomment %}
   <div class="location map card">
     <!-- map -->
-    {% if user.is_authenticated %}
+    {% if user.is_authenticated or allow_unauthenticated_see_overview_map %}
       <h3>{{ location.name }} {% translate 'on the map'|title %}:</h3>
       <div id="map" class="large-map">
         {% if not maps_permission %}
@@ -63,7 +63,7 @@
         {% comment %} locationTag.innerHTML = "<a href='{{ location.get_absolute_url }}'>{{ location.name }}</a>"; {% endcomment %}
         
         // List secondary locations
-        {% if user.is_authenticated %}
+        {% if user.is_authenticated or allow_unauthenticated_see_overview_map %}
           {% for location in location_list %}
             {% if location.coord_lat and location.coord_lng %}
               const pin{{ location.id }} = new PinElement({

--- a/location/templates/snippets/location_list_filters.html
+++ b/location/templates/snippets/location_list_filters.html
@@ -6,7 +6,7 @@
     <!-- Quick filters and actions -->
     |
     {% if active_filters|length > 3 %}<a href="{% if location_list.first.isActivity %}{% url 'location:activities' %}{% else %}{% url 'location:locations' %}{% endif %}" title="{% translate 'reset all active filters'|capfirst %}">{% translate 'show all'|capfirst %}</a> |{% endif %}
-    <a href="/map/{% if active_filters.country %}{{ active_filters.country }}/{% endif %}{% if active_filters.region %}{{ active_filters.region }}/{% endif %}{% if active_filters.department %}{{ active_filters.department }}/{% endif %}?{% if active_filters.category %}category={{ active_filters.category|join:"," }}&{% endif %}{% if active_filters.tag %}tag={{ active_filters.tag|join:"," }}&{% endif %}{% if active_filters.favorites %}favorites&{% endif %}">{% translate 'on map'|capfirst %}</a> |
+    {% if user.is_authenticated or allow_unauthenticated_see_overview_map %}<a href="/map/{% if active_filters.country %}{{ active_filters.country }}/{% endif %}{% if active_filters.region %}{{ active_filters.region }}/{% endif %}{% if active_filters.department %}{{ active_filters.department }}/{% endif %}?{% if active_filters.category %}category={{ active_filters.category|join:"," }}&{% endif %}{% if active_filters.tag %}tag={{ active_filters.tag|join:"," }}&{% endif %}{% if active_filters.favorites %}favorites&{% endif %}">{% translate 'on map'|capfirst %}</a> |{% endif %}
     <!-- Special status -->
     {% if available_filters.has_favorites and 'favorites' not in active_filters %}<a href="{% include 'snippets/filter_url_queryparams.html' %}&favorites">{% translate 'only favorites'|capfirst %}</a> | {% endif %}
     <!-- Ordering -->


### PR DESCRIPTION
This introduces a new settings line:
> ALLOW_UNAUTHENTICATED_SEE_OVERVIEW_MAP = True # Allow unauthenticated users to see the overview map

Omitting this setting will default to False

Without this setting or when set to False, the link to map on a search page is omitted, and the /map page is empty.
With this setting set to True, unauthenticated users can see the map
![image](https://github.com/user-attachments/assets/85b1e1b0-4e94-428b-b379-d1a075899e7f)
