### PR TITLE
Simplify ajax and context processors

### DIFF
--- a/location/context_processors.py
+++ b/location/context_processors.py
@@ -3,12 +3,14 @@ from django.conf import settings
 # Define content that will be available in templates
 def setting_data(request):
   return {
-    'app_title': settings.APP_TITLE if hasattr(settings, 'APP_TITLE') else 'VKNT',
-    'meta_description': settings.META_DESCRIPTION if hasattr(settings, 'META_DESCRIPTION') else 'Online vacation planning tool',
-    'language_code': settings.LANGUAGE_CODE,
+    'app_title': getattr(settings, 'APP_TITLE', 'VKNT'),
+    'meta_description': getattr(settings, 'META_DESCRIPTION', 'Online vacation planning tool'),#
+    'language_code': getattr(settings, 'LANGUAGE_CODE', 'en'),
     'google_maps_api_key': settings.GOOGLE_MAPS_API_KEY,
-    'default_order': settings.DEFAULT_ORDER if hasattr(settings, 'DEFAULT_ORDER') else 'distance',
-    'allow_unauthenticated_read_comments': settings.ALLOW_UNAUTHENTICATED_READ_COMMENTS if hasattr(settings, 'ALLOW_UNAUTHENTICATED_READ_COMMENTS') else False,
-    'allow_unauthenticated_see_overview_map': settings.ALLOW_UNAUTHENTICATED_SEE_OVERVIEW_MAP if hasattr(settings, 'ALLOW_UNAUTHENTICATED_SEE_OVERVIEW_MAP') else False,
-    'departure_center': settings.DEPARTURE_CENTER if hasattr(settings, 'DEPARTURE_CENTER') else 'Domplein, Utrecht',
+    'default_order': getattr(settings, 'DEFAULT_ORDER', 'distance'),
+    'allow_unauthenticated_read_comments': getattr(settings, 'ALLOW_UNAUTHENTICATED_READ_COMMENTS', False),
+    'allow_unauthenticated_see_overview_map': getattr(settings, 'ALLOW_UNAUTHENTICATED_SEE_OVERVIEW_MAP', False),
+    'departure_center': getattr(settings, 'DEPARTURE_CENTER', 'Domplein, Utrecht'),
+
+    'ajax_load_comments': getattr(settings, 'AJAX_LOAD_COMMENTS', False),
   }

--- a/location/templates/location/comment_list.html
+++ b/location/templates/location/comment_list.html
@@ -5,7 +5,9 @@
 
 <div class="comment list card">
   <h1>{% translate 'comments'|title %}</h1>
-  {% include 'snippets/list_comments.html' %}
+  {% for comment in comment_list %}
+    {% include 'partial/comment.html' %}
+  {% endfor %}
 </div>
 
 {% endblock %}


### PR DESCRIPTION
- List Comments should use partial rendering and rendered content in ajax payload, avoid rendering via javascript
- Context Processors can be simplified