### PR TITLE
fix action list location colouring when media is present

### DIFF
--- a/location/templates/location/location/location_detail.html
+++ b/location/templates/location/location/location_detail.html
@@ -324,7 +324,7 @@
         {% if ajax_load_categories %}/** Load categories */getLocationAttributes('{% url 'location:getAttributesFor' location.slug 'category' %}', 'categorylist'){% endif %}
         {% if ajax_load_chains %}/** Load chains */getLocationAttributes('{% url 'location:getAttributesFor' location.slug 'chain' %}', 'chainlist'){% endif %}
         {% if ajax_load_comments %}/** Load comments */getLocationAttributes('{% url 'location:getAttributesFor' location.slug 'comment' %}', 'commentlist'){% endif %}
-        {% if ajax_load_actionlist %}/** Load action list */getLocationAttributes('{% url 'location:getAttributesFor' location.slug 'actionlist' %}', 'actionlist'){% endif %}
+        {% if ajax_load_actionlist %}/** Load action list */getLocationAttributes('{% url 'location:getAttributesFor' location.slug 'actionlist' %}?field=media', 'actionlist'){% endif %}
       });
     </script>
   {% endif %}

--- a/location/views/json/getlocationattributes.py
+++ b/location/views/json/getlocationattributes.py
@@ -75,12 +75,19 @@ class JSONGetLocationAttributes(View, FilterClass):
       queryset = self.get_queryset(location=location)
     except Exception as e:
       return JsonResponse({'message': f"{ _('queryset not supported').capitalize() }: { e }"}, status=500)
+    ''' Process Additional Field'''
+    field = self.request.GET.get('field', None)
+    if field:
+      field_data = self.filter(getattr(location, field).all())
     # if not queryset:
     #   return JsonResponse({'message': f"{ _('No {} data found for location').format(attribute) } { location }"}, status=500)
     ''' Build Response '''
     response = []
     for object in queryset:
       seperator = '' if queryset.last() == object else ', '
-      payload = render_to_string(f'partial/{ attribute }.html', {attribute: object, 'location': location, 'user': request.user}, request=request)
+      if field:
+        payload = render_to_string(f'partial/{ attribute }.html', {attribute: object, 'location': location, 'user': request.user, field:field_data}, request=request)
+      else:
+        payload = render_to_string(f'partial/{ attribute }.html', {attribute: object, 'location': location, 'user': request.user}, request=request)
       response.append(payload + seperator)
     return JsonResponse({'payload': response,}, status=200)


### PR DESCRIPTION
Resolves issue #335 
Problem was that the icon colour was set by if there is media to show. However, the Media object was not passed to the partial. By adding a ?field= optional parameter, the media field can be accessed and will be passed to the render_to_string() function