### PR TITLE
handle parent/child relations when toggle an attribute that is new

### DIFF
--- a/location/static/js/getAutocompleteValues.js
+++ b/location/static/js/getAutocompleteValues.js
@@ -77,7 +77,9 @@ $(document).ready(function() {
       success: function(data) {
         getLocationAttributes(data['success-url'], data['target']);
         $('input#' + target).val('');
-        $('#messages-placeholder').append('<div class="alert alert-success" role="alert">' + data['message'] + '</div>');
+        $('input#' + target).data('slug', '');
+        $('#messages-placeholder').append('<div class="alert alert-success alert-dismissible fade show" role="alert">' + data.message + '  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>');
+        // $('#messages-placeholder').append('<div class="alert alert-success" role="alert">' + data['message'] + '</div>');
       },
       error: function(data) {
         console.log('Error' + data['message']);

--- a/location/static/js/getLocationAttributes.js
+++ b/location/static/js/getLocationAttributes.js
@@ -14,7 +14,7 @@ function getLocationAttributes(url, target) {
     success: function(data){
       // console.log(data);
       if (data.error == true) {
-        $('#attributemessages').append('<div class="alert alert-danger alert-dismissible fade show" role="alert">' + data.message + '  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>');
+        $('#messages-placeholder').append('<div class="alert alert-danger alert-dismissible fade show" role="alert">' + data.message + '  <button type="button" class="btn-close" data-bs-dismiss="alert" aria-label="Close"></button></div>');
         console.log('Error: ' + data.message);
         return false;
       } else {


### PR DESCRIPTION
Progess on #316 
When toggling an attribute, for example tag, category, etc, check if the : is in the content. If it is, the part before the : should be considered the parent. Use get_or_create to fetch the parent, and when creating the child tag, attach to the parent.
This does not change relations of an existing tag, since the parent reference is only applied in the defaults={} section.