### PR TITLE
add sendfile to stream media and allow authentication check

### DIFF
--- a/location/urls.py
+++ b/location/urls.py
@@ -102,6 +102,7 @@ urlpatterns = [
   path('media/stack/<str:slug>/', views.StackView.as_view(), name='MediaStack'),
   path('media/refresh/<str:slug>:<pk>/', views.MediaRefreshView.as_view(), name='MediaRefresh'),
   # path('media/delete/<object_slug>:<pk>', views.ToggleMediaDeleted.as_view(), name='MediaDelete'),
+  path('media/<str:filename>', views.MediaStreamView.as_view(), name='MediaStream'),
   path('register/', views.SignUpView.as_view(), name='register'),
 
   # Toggle Views 

--- a/requirements.txt
+++ b/requirements.txt
@@ -16,5 +16,8 @@ Markdown >= 3.7
 # Heic to JPG
 pillow-heif >= 0.21.0
 
+# Sendfile for Attachments
+django-sendfile2 >= 0.7.0
+
 # OpenAI (experimental)
 openai >= 1.58.1


### PR DESCRIPTION
Resolves the issue for #383 
Use Sendfile to stream images to the user, after checking the visibility rights.
Sendfile requires the following changes to settings.py:
**For development:**
`
''' Sendfile Configuration
    Sendfile is used for authenticated downloads, as for attachments
'''
SENDFILE_ROOT = MEDIA_ROOT
SENDFILE_BACKEND = 'django_sendfile.backends.development'
`
**For production**:
Add to installed apps: `django_sendfile`
`
''' Sendfile Configuration '''
SENDFILE_ROOT = MEDIA_ROOT.joinpath('files')
SENDFILE_BACKEND = 'django_sendfile.backends.nginx'
SENDFILE_URL = '/media/'
`