### PR TITLE
always show nearby - even if there is nothing to show

### DIFF
--- a/location/templates/location/location/location_detail.html
+++ b/location/templates/location/location/location_detail.html
@@ -189,11 +189,9 @@
       
 
         <!-- Nearby -->
-        {% if location.nearby %}
-          <div class="nearby locations card" id="nearby">
-            {% comment %} {% include 'function/location_nearby.html' %} {% endcomment %}
-          </div>
-        {% endif %}
+        <div class="nearby locations card" id="nearby">
+          {% comment %} {% include 'function/location_nearby.html' %} {% endcomment %}
+        </div>
 
       {% endif %}
     {% endif %}


### PR DESCRIPTION
if not - this triggers a warning when nearby is loaded but nothing is shown.